### PR TITLE
Respect `TESTCONTAINERS_RYUK_DISABLED` ENV flag

### DIFF
--- a/lib/testcontainers.ex
+++ b/lib/testcontainers.ex
@@ -58,13 +58,12 @@ defmodule Testcontainers do
       |> Base.encode16()
 
     with {:ok, docker_hostname} <- get_docker_hostname(docker_host_url, conn),
-         {:ok, socket} <- start_reaper(conn, session_id, properties, docker_host, docker_hostname),
+         {:ok} <- start_reaper(conn, session_id, properties, docker_host, docker_hostname),
          {:ok, properties} <- PropertiesParser.read_property_file() do
       Logger.info("Testcontainers initialized")
 
       {:ok,
        %{
-         socket: socket,
          conn: conn,
          docker_hostname: docker_hostname,
          session_id: session_id,
@@ -282,7 +281,7 @@ defmodule Testcontainers do
          {:ok, container} <- Api.get_container(ryuk_container_id, conn),
          {:ok, socket} <- create_ryuk_socket(container, docker_hostname),
          :ok <- register_ryuk_filter(session_id, socket) do
-      {:ok, socket}
+      {:ok}
     end
   end
 


### PR DESCRIPTION
Hello,

I'm trying to use testcontainers for an elixir project on a mac with podman. Under some conditions the stars must align for it to work, as such for me. I followed these steps here:

- https://podman-desktop.io/tutorial/testcontainers-with-podman
- https://podman-desktop.io/docs/migrating-from-docker/customizing-docker-compatibility
- https://www.baeldung.com/java-podman-configure-testcontainers

With all the different errors:

```
** (EXIT from #PID<0.94.0>) {:error, {:failed_to_create_container, %DockerEngineAPI.Model.ErrorResponse{message: "make cli opts(): making volume mountpoint for volume /var/folders/95/bfjp2z0x5l57lzbp6c047rxw0000gn/T/podman/podman-machine-default-api.sock: mkdir /var/folders/95/bfjp2z0x5l57lzbp6c047rxw0000gn/T/podman/podman-machine-default-api.sock: operation not supported"}}}
```

```
** (EXIT from #PID<0.94.0>) {:error, {:failed_to_register_ryuk_filter, :closed}}
```

```
[info] Docker host: {"http+unix://%2Fvar%2Frun%2Fdocker.sock", "unix:///var/run/docker.sock"}

[debug] Not running in docker environment, using localhost

[info] Connection refused. Retrying... Attempt 1/3

[info] Connection refused. Retrying... Attempt 2/3

[info] Connection refused. Retrying... Attempt 3/3

[info] Ryuk host refused to connect
** (EXIT from #PID<0.94.0>) {:error, :econnrefused}
```

the errors center around `ryuk`. I still dunno what that is to be fair, but I understand it as a container to assist managing other containers. Though this _can_ lead to problems under podman(/mac). And the docs recommend to turn off `ryuk` with this flag:

```sh
export TESTCONTAINERS_RYUK_DISABLED=true
```

however, nothing changed for me. When I searched for this env var on this repo, the results were empty and I had my answer. I searched the node and java repo for that env var and they had implementations for it.

I looked into the node impl and I thought to give it a shot. I made a very stubborn form for my impl. I'd say it acts more of a poc. I run the tests, too - I had 5 timeouts. Compared to before were no tests ran at all, this is a very good improvement 😁 

Also I used this fork, used it as path dep to my actual project, and could run the tests over there - yeah 🥳 

I think the POC is looking quite promising. There is plenty ways to write my code changes. I dunno what would match your style (also I'm still quite fresh to elixir). I'd kindly ask you to take over my PR.

Thanks a lot.